### PR TITLE
new-cnpj-format-IN-RFB-2229

### DIFF
--- a/src/NBrzId.Common/BaseBrzIdentifier.cs
+++ b/src/NBrzId.Common/BaseBrzIdentifier.cs
@@ -4,10 +4,11 @@ namespace NBrzId.Common
 {
     public abstract class BaseBrzIdentifier : IBrzIdentifier
     {
-        public virtual char[] FormattingCharacters => Mask?.Where(c => c != 'N' && c != 'A')?.ToArray();
+        public virtual char[] FormattingCharacters => Mask?.Where(c => c != 'N' && c != 'A' && c != 'X')?.ToArray();
         
         public abstract char   PaddingCharacter { get; }
         public abstract int    Length           { get; }
         public abstract string Mask             { get; }
     }
 }
+

--- a/src/NBrzId.Common/Cnpj.cs
+++ b/src/NBrzId.Common/Cnpj.cs
@@ -9,7 +9,7 @@
     /// and access to properties specific to CNPJ identifiers. 
     /// <list type="bullet">
     ///     <item><description><see cref="Length"/> indicates the standard number of digits in a CNPJ (14 digits).</description></item>
-    ///     <item><description><see cref="Mask"/> defines the CNPJ format, e.g., "NN.NNN.NNN/NNNN-NN".</description></item>
+    ///     <item><description><see cref="Mask"/> defines the CNPJ format, e.g., "XX.XXX.XXX/XXXX-NN".</description></item>
     ///     <item><description><see cref="FormattingCharacters"/> specifies CNPJ formatting symbols (periods, slashes, and hyphen).</description></item>
     ///     <item><description><see cref="PaddingCharacter"/> specifies a character used for left padding the identifier if the provided value is shorter than <see cref="Length"/>.</description></item>
     /// </list>
@@ -20,7 +20,7 @@
         internal static Cnpj Instance => _instance;
 
         public override int    Length           => 14;
-        public override string Mask             => "NN.NNN.NNN/NNNN-NN";
+        public override string Mask             => "XX.XXX.XXX/XXXX-NN";
         public override char   PaddingCharacter => '0';
 
         static Cnpj()
@@ -32,3 +32,4 @@
         { }
     }
 }
+

--- a/src/NBrzId.Common/NBrzId.Common.csproj
+++ b/src/NBrzId.Common/NBrzId.Common.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <BaseOutputPath>bin\</BaseOutputPath>
     <BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
     <PackageId>NBrzId.Common</PackageId>
-    <Version>0.1.2</Version>
     <Authors>Christian Martins</Authors>
     <Description>Implementation of common types used for Brazilian identifiers management (validation, formatting etc.)</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/NBrzId.Common.UnitTests/CnpjTests.cs
+++ b/tests/NBrzId.Common.UnitTests/CnpjTests.cs
@@ -33,7 +33,7 @@ namespace NBrzId.Common.Tests
         {
             var actual = Cnpj.Instance.Mask;
 
-            Assert.Equal("NN.NNN.NNN/NNNN-NN", actual);
+            Assert.Equal("XX.XXX.XXX/XXXX-NN", actual);
         }
 
         [Fact]
@@ -44,4 +44,5 @@ namespace NBrzId.Common.Tests
             Assert.Equal('0', actual);
         }
     }
+
 }

--- a/tests/NBrzId.Common.UnitTests/NBrzId.Common.UnitTests.csproj
+++ b/tests/NBrzId.Common.UnitTests/NBrzId.Common.UnitTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,3 +31,4 @@
   </ItemGroup>
 
 </Project>
+


### PR DESCRIPTION
Added support for the new CNPJ alphanumeric format according to "Instrução Normativa RFB nº 2229"; reference:

- [CNPJ Alfanumérico - Receita Federal](https://www.gov.br/receitafederal/pt-br/acesso-a-informacao/acoes-e-programas/programas-e-atividades/cnpj-alfanumerico)